### PR TITLE
Fix no origin props

### DIFF
--- a/src/components/Cards.js
+++ b/src/components/Cards.js
@@ -200,7 +200,7 @@ class Cards extends React.Component {
   }
 
   renderCarousel () {
-    if (!this.state.sliderWidth || !this.state.itemWidth || !this.props.data) {
+    if (!this.props.origin || !this.state.sliderWidth || !this.state.itemWidth || !this.props.data) {
       return null;
     }
     return (


### PR DESCRIPTION
SnapCarousels renderDefaultItem uses `this.props.origin` and app will
crash if origin is null, this happens in example app where Cards
renders before onLocationChange is fired from CurrentLocation.

(While testing example app was crashing sometimes and it turned out to be a reason)